### PR TITLE
bump to 1.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,10 @@ RUN curl -L -o vbox.dmg http://download.virtualbox.org/virtualbox/4.3.12/Virtual
 
 # Download the Docker parts
 
-ENV DOCKER_VERSION  1.1.2
-ENV BOOT2DOCKER_CLI_VERSION 1.1.2
-ENV BOOT2DOCKER_ISO_VERSION .1.1.2
-ENV INSTALLER_VERSION 1.1.2
+ENV DOCKER_VERSION  1.2.0
+ENV BOOT2DOCKER_CLI_VERSION 1.2.0
+ENV BOOT2DOCKER_ISO_VERSION 1.2.0
+ENV INSTALLER_VERSION 1.2.0
 
 RUN curl -L -o /docker.tgz http://get.docker.io/builds/Darwin/x86_64/docker-$DOCKER_VERSION.tgz
 RUN curl -L -o /boot2docker https://github.com/boot2docker/boot2docker-cli/releases/download/v${BOOT2DOCKER_CLI_VERSION}/boot2docker-v${BOOT2DOCKER_CLI_VERSION}-darwin-amd64

--- a/mpkg/boot2docker.app/Contents/Info.plist
+++ b/mpkg/boot2docker.app/Contents/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.2</string>
+	<string>1.2.0</string>
 	<key>CFBundleSignature</key>
 	<string>aplt</string>
 	<key>LSMinimumSystemVersionByArchitecture</key>


### PR DESCRIPTION
don't merge until Docker 1.2.0 is released.
