### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@ How to build
 ============
 
 Running `make` will produce a `Docker.pkg` installer.
+
+How to uninstall
+================
+
+curl https://raw.githubusercontent.com/boot2docker/osx-installer/master/uninstall.sh | sudo bash


### PR DESCRIPTION
Add a quick command on how to uninstall.  

uninstall.sh did not remove:
/usr/local/bin/boot2docker.bak (not sure where this came from, maybe an update or new install)
/Applications/boot2docker.app/
